### PR TITLE
Handle negative ms values

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (ms) {
 	if (typeof ms !== 'number') {
 		throw new TypeError('Expected a number');
 	}
-	
+
 	var roundTowardZero = ms > 0 ? Math.floor : Math.ceil;
 
 	return {

--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ module.exports = function (ms) {
 	if (typeof ms !== 'number') {
 		throw new TypeError('Expected a number');
 	}
+	
+	var roundTowardZero = ms > 0 ? Math.floor : Math.ceil;
 
 	return {
-		days: (ms / 86400000) | 0,
-		hours: (ms / 3600000 % 24) | 0,
-		minutes: (ms / 60000 % 60) | 0,
-		seconds: (ms / 1000 % 60) | 0,
-		milliseconds: (ms % 1000) | 0
+		days: roundTowardZero(ms / 86400000),
+		hours: roundTowardZero(ms / 3600000) % 24,
+		minutes: roundTowardZero(ms / 60000) % 60,
+		seconds: roundTowardZero(ms / 1000) % 60,
+		milliseconds: roundTowardZero(ms) % 1000
 	};
 };

--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ module.exports = function (ms) {
 	}
 
 	return {
-		days: Math.floor(ms / 86400000),
-		hours: Math.floor(ms / 3600000 % 24),
-		minutes: Math.floor(ms / 60000 % 60),
-		seconds: Math.floor(ms / 1000 % 60),
-		milliseconds: Math.floor(ms % 1000)
+		days: (ms / 86400000) | 0,
+		hours: (ms / 3600000 % 24) | 0,
+		minutes: (ms / 60000 % 60) | 0,
+		seconds: (ms / 1000 % 60) | 0,
+		milliseconds: (ms % 1000) | 0
 	};
 };

--- a/test.js
+++ b/test.js
@@ -67,3 +67,23 @@ it('should parse milliseconds into an object', function () {
 		milliseconds: 0
 	});
 });
+
+it('should handle negative millisecond values', function () {
+  [
+    100 + 400,
+    1000 * 55,
+    1000 * 67,
+    1000 * 60 * 5,
+    1000 * 60 * 67,
+    1000 * 60 * 60 * 12,
+    1000 * 60 * 60 * 40,
+    1000 * 60 * 60 * 999
+  ].forEach(function (ms) {
+    var positive = parseMs(ms)
+    var negative = parseMs(-ms)
+    for (var key in negative) {
+      assert.equal(negative[key], -positive[key]);
+    }
+  })
+});
+

--- a/test.js
+++ b/test.js
@@ -69,21 +69,27 @@ it('should parse milliseconds into an object', function () {
 });
 
 it('should handle negative millisecond values', function () {
-  [
-    100 + 400,
-    1000 * 55,
-    1000 * 67,
-    1000 * 60 * 5,
-    1000 * 60 * 67,
-    1000 * 60 * 60 * 12,
-    1000 * 60 * 60 * 40,
-    1000 * 60 * 60 * 999
-  ].forEach(function (ms) {
-    var positive = parseMs(ms)
-    var negative = parseMs(-ms)
-    for (var key in negative) {
-      assert.equal(negative[key], -positive[key]);
-    }
-  })
+	[
+		100 + 400,
+		1000 * 55,
+		1000 * 67,
+		1000 * 60 * 5,
+		1000 * 60 * 67,
+		1000 * 60 * 60 * 12,
+		1000 * 60 * 60 * 40,
+		1000 * 60 * 60 * 999
+	].forEach(function (ms) {
+		var positive = parseMs(ms);
+		var negative = parseMs(-ms);
+		[
+			'days',
+			'hours',
+			'minutes',
+			'seconds',
+			'milliseconds'
+		].forEach(function (key) {
+			assert.equal(negative[key], -positive[key]);
+		});
+	});
 });
 


### PR DESCRIPTION
Currently, doing `parseMs(-1)` yields `{ days: -1, hours: -1, minutes: -1, seconds: -1, milliseconds: -1 }`, whereas I'd expect `{ days: 0, hours: 0, minutes: 0, seconds: 0, milliseconds: -1 }`.

This patch yields the latter by using `num | 0` to round "towards zero" instead of `Math.floor(num)`.
