### PR TITLE
Fix `NaN` microseconds and nanoseconds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 12
+          - 20
+          - 18
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export interface TimeComponents {
+export type TimeComponents = {
 	days: number;
 	hours: number;
 	minutes: number;
@@ -6,7 +6,7 @@ export interface TimeComponents {
 	milliseconds: number;
 	microseconds: number;
 	nanoseconds: number;
-}
+};
 
 /**
 Parse milliseconds into an object.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const toZeroIfInfinity = value => Number.isFinite(value) ? value : 0;
+
 export default function parseMilliseconds(milliseconds) {
 	if (typeof milliseconds !== 'number') {
 		throw new TypeError('Expected a number');
@@ -5,11 +7,11 @@ export default function parseMilliseconds(milliseconds) {
 
 	return {
 		days: Math.trunc(milliseconds / 86400000),
-		hours: Math.trunc(milliseconds / 3600000) % 24,
-		minutes: Math.trunc(milliseconds / 60000) % 60,
-		seconds: Math.trunc(milliseconds / 1000) % 60,
-		milliseconds: Math.trunc(milliseconds) % 1000,
-		microseconds: Math.trunc(milliseconds * 1000) % 1000,
-		nanoseconds: Math.trunc(milliseconds * 1e6) % 1000
+		hours: Math.trunc(milliseconds / 3600000 % 24),
+		minutes: Math.trunc(milliseconds / 60000 % 60),
+		seconds: Math.trunc(milliseconds / 1000 % 60),
+		milliseconds: Math.trunc(milliseconds % 1000),
+		microseconds: Math.trunc(toZeroIfInfinity(milliseconds * 1000) % 1000),
+		nanoseconds: Math.trunc(toZeroIfInfinity(milliseconds * 1e6) % 1000)
 	};
 }

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ export default function parseMilliseconds(milliseconds) {
 	}
 
 	return {
-		days: Math.trunc(milliseconds / 86400000),
-		hours: Math.trunc(milliseconds / 3600000 % 24),
-		minutes: Math.trunc(milliseconds / 60000 % 60),
+		days: Math.trunc(milliseconds / 86_400_000),
+		hours: Math.trunc(milliseconds / 3_600_000 % 24),
+		minutes: Math.trunc(milliseconds / 60_000 % 60),
 		seconds: Math.trunc(milliseconds / 1000 % 60),
 		milliseconds: Math.trunc(milliseconds % 1000),
 		microseconds: Math.trunc(toZeroIfInfinity(milliseconds * 1000) % 1000),
-		nanoseconds: Math.trunc(toZeroIfInfinity(milliseconds * 1e6) % 1000)
+		nanoseconds: Math.trunc(toZeroIfInfinity(milliseconds * 1e6) % 1000),
 	};
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType} from 'tsd';
-import parseMilliseconds, {TimeComponents} from './index.js';
+import parseMilliseconds, {type TimeComponents} from './index.js';
 
 const components: TimeComponents = parseMilliseconds(3000);
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12"
+		"node": ">=12.5"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -38,6 +38,6 @@
 	"devDependencies": {
 		"ava": "^3.15.0",
 		"tsd": "^0.14.0",
-		"xo": "^0.38.2"
+		"xo": "^0.56.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"type": "module",
 	"exports": "./index.js",
 	"engines": {
-		"node": ">=12.5"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -36,8 +36,8 @@
 		"interval"
 	],
 	"devDependencies": {
-		"ava": "^3.15.0",
-		"tsd": "^0.14.0",
+		"ava": "^6.0.1",
+		"tsd": "^0.30.3",
 		"xo": "^0.56.0"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 1,
 		milliseconds: 400,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(1000 * 55), {
@@ -19,7 +19,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 55,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(1000 * 67), {
@@ -29,7 +29,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 7,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(1000 * 60 * 5), {
@@ -39,7 +39,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 0,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(1000 * 60 * 67), {
@@ -49,7 +49,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 0,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(1000 * 60 * 60 * 12), {
@@ -59,7 +59,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 0,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(1000 * 60 * 60 * 40), {
@@ -69,7 +69,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 0,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(1000 * 60 * 60 * 999), {
@@ -79,37 +79,37 @@ test('parse milliseconds into an object', t => {
 		seconds: 0,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
-	t.deepEqual(parseMilliseconds((1000 * 60) + 500 + 0.345678), {
+	t.deepEqual(parseMilliseconds((1000 * 60) + 500 + 0.345_678), {
 		days: 0,
 		hours: 0,
 		minutes: 1,
 		seconds: 0,
 		milliseconds: 500,
 		microseconds: 345,
-		nanoseconds: 678
+		nanoseconds: 678,
 	});
 
-	t.deepEqual(parseMilliseconds(0.000543), {
+	t.deepEqual(parseMilliseconds(0.000_543), {
 		days: 0,
 		hours: 0,
 		minutes: 0,
 		seconds: 0,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 543
+		nanoseconds: 543,
 	});
 
 	t.deepEqual(parseMilliseconds(Number.MAX_VALUE), {
-		days: 2.0806633505350875e+300,
+		days: 2.080_663_350_535_087_5e+300,
 		hours: 8,
 		minutes: 8,
 		seconds: 48,
 		milliseconds: 368,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 
 	t.deepEqual(parseMilliseconds(Number.MIN_VALUE), {
@@ -119,7 +119,7 @@ test('parse milliseconds into an object', t => {
 		seconds: 0,
 		milliseconds: 0,
 		microseconds: 0,
-		nanoseconds: 0
+		nanoseconds: 0,
 	});
 });
 
@@ -129,7 +129,7 @@ test('handle negative millisecond values', t => {
 		'hours',
 		'minutes',
 		'seconds',
-		'milliseconds'
+		'milliseconds',
 	];
 
 	const times = [
@@ -142,7 +142,7 @@ test('handle negative millisecond values', t => {
 		1000 * 60 * 67,
 		1000 * 60 * 60 * 12,
 		1000 * 60 * 60 * 40,
-		1000 * 60 * 60 * 999
+		1000 * 60 * 60 * 999,
 	];
 
 	for (const milliseconds of times) {

--- a/test.js
+++ b/test.js
@@ -101,6 +101,26 @@ test('parse milliseconds into an object', t => {
 		microseconds: 0,
 		nanoseconds: 543
 	});
+
+	t.deepEqual(parseMilliseconds(Number.MAX_VALUE), {
+		days: 2.0806633505350875e+300,
+		hours: 8,
+		minutes: 8,
+		seconds: 48,
+		milliseconds: 368,
+		microseconds: 0,
+		nanoseconds: 0
+	});
+
+	t.deepEqual(parseMilliseconds(Number.MIN_VALUE), {
+		days: 0,
+		hours: 0,
+		minutes: 0,
+		seconds: 0,
+		milliseconds: 0,
+		microseconds: 0,
+		nanoseconds: 0
+	});
 });
 
 test('handle negative millisecond values', t => {


### PR DESCRIPTION
```js
parseMilliseconds(Number.MAX_VALUE)

{
  days: 2.0806633505350875e+300,
  hours: 8,
  minutes: 8,
  seconds: 48,
  milliseconds: 368,
  microseconds: NaN,
  nanoseconds: NaN
}
```